### PR TITLE
Make shelf_rpc depend on latest version of the RPC package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 `shelf_rpc` is a Shelf `Handler` for the Dart `rpc` package.
 
 ### Example
-```
+```dart
 import 'package:rpc/rpc.dart';
 import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_rpc/shelf_rpc.dart' as shelf_rpc;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_rpc
-version: 0.0.3
+version: 0.0.3+1
 author: Dart Team <misc@dartlang.org>
 description: RPC package API support for Shelf
 homepage: https://github.com/dart-lang/shelf_rpc
@@ -9,4 +9,4 @@ environment:
 
 dependencies:
   shelf: ">=0.5.0 <0.6.0"
-  rpc: ">=0.4.0 <0.5.0"
+  rpc: ">=0.5.0 <0.6.0"


### PR DESCRIPTION
This fixes an issue with a circular dev_dependency from the RPC package back to the shelf_rpc package. We should probably move the shelf RPC example to the shelf_rpc package to avoid the circular dependency.
